### PR TITLE
switch to deep links

### DIFF
--- a/src/common/links.js
+++ b/src/common/links.js
@@ -1,4 +1,4 @@
-const baseUrl = 'com.nintendo.znca://znca/game/4834290508791808';
+const baseUrl = 'https://s.nintendo.com/av5ja-lp1/znca/game/4834290508791808';
 
 export function getGesotownGearUrl(id) {
   return `${baseUrl}?p=/gesotown/${id}`


### PR DESCRIPTION
Deep links should open the app without a prompt. Additionally, on devices without the app or on computers, the link redirects to https://dpl.lp1.av5ja.srv.nintendo.net/