### PR TITLE
fix(i18n): <GearCardHorizontal> display `gear.saleEndTime` via i18n

### DIFF
--- a/src/components/gear/GearCardHorizontal.vue
+++ b/src/components/gear/GearCardHorizontal.vue
@@ -9,8 +9,7 @@
     <div class="grow min-w-0 flex flex-col justify-evenly space-y-2">
       <div class="flex">
         <div class="inline-block text-xs bg-zinc-200 bg-opacity-30 rounded px-1 py-px font-semibold">
-          {{ formatShortDurationFromNow(props.gear.saleEndTime) }}
-          left
+          {{ $t('time.left', { time: formatShortDurationFromNow(props.gear.saleEndTime) }) }}
         </div>
       </div>
 


### PR DESCRIPTION
(fixes #16)