### PR TITLE
Splatfest calendars

### DIFF
--- a/app/data/ImageProcessor.mjs
+++ b/app/data/ImageProcessor.mjs
@@ -22,7 +22,7 @@ export default class ImageProcessor
     await this.maybeDownload(url, destination);
 
     // Return the new public URL
-    return this.publicUrl(destination);
+    return [destination, this.publicUrl(destination)];
   }
 
   normalize(url) {

--- a/app/data/ImageProcessor.mjs
+++ b/app/data/ImageProcessor.mjs
@@ -34,7 +34,7 @@ export default class ImageProcessor
   }
 
   publicUrl(file) {
-    return `${this.siteUrl}/${this.outputDirectory}/${file}`;
+    return `${this.siteUrl ?? ''}/${this.outputDirectory}/${file}`;
   }
 
   async exists(file) {

--- a/app/data/index.mjs
+++ b/app/data/index.mjs
@@ -3,21 +3,24 @@ import StageScheduleUpdater from "./updaters/StageScheduleUpdater.mjs";
 import CoopUpdater from "./updaters/CoopUpdater.mjs";
 import FestivalUpdater from "./updaters/FestivalUpdater.mjs";
 import CurrentFestivalUpdater from "./updaters/CurrentFestivalUpdater.mjs";
+import { regionTokens } from "../splatnet/NsoClient.mjs";
 
 function updaters() {
+  const tokens = regionTokens();
+
   return [
     new StageScheduleUpdater,
     new GearUpdater,
     new CoopUpdater,
-    new FestivalUpdater('US'),
-    new FestivalUpdater('EU'),
-    new FestivalUpdater('JP'),
-    new FestivalUpdater('AP'),
-    new CurrentFestivalUpdater('US'),
-    new CurrentFestivalUpdater('EU'),
-    new CurrentFestivalUpdater('JP'),
-    new CurrentFestivalUpdater('AP'),
-  ];
+    tokens.US && new FestivalUpdater('US'),
+    tokens.EU && new FestivalUpdater('EU'),
+    tokens.JP && new FestivalUpdater('JP'),
+    tokens.AP && new FestivalUpdater('AP'),
+    tokens.US && new CurrentFestivalUpdater('US'),
+    tokens.EU && new CurrentFestivalUpdater('EU'),
+    tokens.JP && new CurrentFestivalUpdater('JP'),
+    tokens.AP && new CurrentFestivalUpdater('AP'),
+  ].filter(u => u);
 }
 
 export async function updateAll() {

--- a/app/data/updaters/DataUpdater.mjs
+++ b/app/data/updaters/DataUpdater.mjs
@@ -182,7 +182,7 @@ export default class DataUpdater
     if (!events) return;
 
     const ical = await this.getiCalData(events, images);
-    this.writeFile(this.getCalendarPath(this.calendarFilename ?? this.filename), ical);
+    await this.writeFile(this.getCalendarPath(this.calendarFilename ?? this.filename), ical);
   }
 
   getCalendarPath(filename) {
@@ -197,10 +197,10 @@ export default class DataUpdater
     // Create a calendar object
     const calendar = new ical({
       name: this.calendarName ?? this.name,
-      url: 'https://splatoon3.ink',
+      url: process.env.SITE_URL,
       prodId: {
-        company: 'splatoon3.ink',
-        product: 'splatoon3.ink',
+        company: 'Splatoon3.ink',
+        product: 'Splatoon3.ink',
         language: 'EN',
       },
       timezone: 'UTC',

--- a/app/data/updaters/DataUpdater.mjs
+++ b/app/data/updaters/DataUpdater.mjs
@@ -2,6 +2,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import mkdirp from 'mkdirp';
 import jsonpath from 'jsonpath';
+import ical from 'ical-generator';
 import prefixedConsole from "../../common/prefixedConsole.mjs";
 import SplatNet3Client from "../../splatnet/SplatNet3Client.mjs";
 import ImageProcessor from '../ImageProcessor.mjs';
@@ -14,6 +15,8 @@ export default class DataUpdater
 {
   name = null;
   filename = null;
+  calendarName = null;
+  calendarFilename = null;
   outputDirectory = 'dist/data';
   archiveOutputDirectory = 'storage/archive';
 
@@ -64,10 +67,13 @@ export default class DataUpdater
     await this.updateLocalizations(this.defaultLocale, data);
 
     // Download any new images
-    await this.downloadImages(data);
+    const images = await this.downloadImages(data);
 
     // Write the data to disk
     await this.saveData(data);
+
+    // Update iCal data
+    await this.updateCalendarEvents(data, images);
 
     this.console.info('Done');
   }
@@ -116,18 +122,24 @@ export default class DataUpdater
   }
 
   async downloadImages(data) {
+    // Return a map of image URLs to their local path
+    const images = {};
+
     for (let expression of this.imagePaths) {
       // This JSONPath library is completely synchronous, so we have to
       // build a mapping here after transforming all URLs.
       let mapping = {};
       for (let url of jsonpath.query(data, expression)) {
-        let publicUrl = await this.imageProcessor.process(url);
+        let [path, publicUrl] = await this.imageProcessor.process(url);
         mapping[url] = publicUrl;
+        images[publicUrl] = path;
       }
 
       // Now apply the URL transformations
       jsonpath.apply(data, expression, url => mapping[url]);
     }
+
+    return images;
   }
 
   // File handling
@@ -161,5 +173,76 @@ export default class DataUpdater
   async writeFile(file, data) {
     await mkdirp(path.dirname(file))
     await fs.writeFile(file, data);
+  }
+
+  // Calendar output
+
+  async updateCalendarEvents(data, images) {
+    const events = this.getCalendarEntries(data);
+    if (!events) return;
+
+    const ical = await this.getiCalData(events, images);
+    this.writeFile(this.getCalendarPath(this.calendarFilename ?? this.filename), ical);
+  }
+
+  getCalendarPath(filename) {
+    return `${this.outputDirectory}/${filename}.ics`;
+  }
+
+  getCalendarEntries(data) {
+    //
+  }
+
+  async getiCalData(events, images) {
+    // Create a calendar object
+    const calendar = new ical({
+      name: this.calendarName ?? this.name,
+      url: 'https://splatoon3.ink',
+      prodId: {
+        company: 'splatoon3.ink',
+        product: 'splatoon3.ink',
+        language: 'EN',
+      },
+      timezone: 'UTC',
+    });
+
+    // Create a map of image URLs to image data
+    const imageData = {};
+
+    // Add event entries
+    for (let event of events) {
+      calendar.createEvent(({
+        id: event.id,
+        summary: event.title,
+        start: event.start,
+        end: event.end,
+        url: event.url,
+        attachments: [event.imageUrl],
+      }));
+
+      const filename = images[event.imageUrl];
+      if (filename) {
+        const data = await fs.readFile(this.imageProcessor.localPath(filename));
+        imageData[event.imageUrl] = data;
+      }
+    }
+
+    // Convert the calendar to an ICS string
+    let ics = calendar.toString();
+
+    // Embed image attachments
+    ics = ics.replaceAll(/^ATTACH:((.|\r\n )*)$/gm, (match, url) => {
+      url = url.replaceAll('\r\n ', '');
+
+      const filename = images[url];
+      const data = imageData[url];
+      if (!filename || !data) return match;
+
+      const ical = `ATTACH;ENCODING=BASE64;VALUE=BINARY;X-APPLE-FILENAME=${path.basename(filename)}:${data.toString('base64')}`;
+
+      return ical.replace(/(.{72})/g, '$1\r\n ').trim();
+    });
+
+    return ics;
   }
 }

--- a/app/data/updaters/FestivalUpdater.mjs
+++ b/app/data/updaters/FestivalUpdater.mjs
@@ -1,6 +1,10 @@
 import fs from 'fs/promises';
 import DataUpdater from "./DataUpdater.mjs";
 
+function getFestId(id) {
+  return Buffer.from(id, 'base64').toString().match(/^Fest-[A-Z]+:(.+)$/)?.[1] ?? id;
+}
+
 function generateFestUrl(id) {
   return process.env.DEBUG ?
     `https://s.nintendo.com/av5ja-lp1/znca/game/4834290508791808?p=/fest_record/${id}` :

--- a/app/data/updaters/FestivalUpdater.mjs
+++ b/app/data/updaters/FestivalUpdater.mjs
@@ -1,10 +1,25 @@
 import fs from 'fs/promises';
 import DataUpdater from "./DataUpdater.mjs";
 
+function generateFestUrl(id) {
+  return process.env.DEBUG ?
+    `https://s.nintendo.com/av5ja-lp1/znca/game/4834290508791808?p=/fest_record/${id}` :
+    `${process.env.SITE_URL ?? ''}/nso/f/${id}`;
+}
+
 export default class FestivalUpdater extends DataUpdater
 {
   name = 'Festivals';
   filename = 'festivals';
+  calendarName = 'Splatoon 3 Splatfests';
+  calendarFilename = 'festivals';
+
+  constructor(region = null) {
+    super(region);
+
+    this.calendarName += ` (${region})`;
+    this.calendarFilename += `.${region}`;
+  }
 
   imagePaths = [
     '$..image.url',
@@ -38,5 +53,18 @@ export default class FestivalUpdater extends DataUpdater
     result[this.region] = data;
 
     return super.formatDataForWrite(result);
+  }
+
+  *getCalendarEntries(data) {
+    for (const fest of data.data.festRecords.nodes) {
+      yield {
+        id: getFestId(fest.id),
+        title: `Splatfest (${this.region}): ${fest.teams.map(t => t.teamName).join(' vs. ')}`,
+        url: generateFestUrl(fest.id),
+        imageUrl: fest.image.url,
+        start: fest.startTime,
+        end: fest.endTime,
+      };
+    }
   }
 }

--- a/app/splatnet/NsoClient.mjs
+++ b/app/splatnet/NsoClient.mjs
@@ -22,6 +22,14 @@ export function regionTokens() {
   };
 }
 
+function getDefaultRegion() {
+  for (const [region, token] of Object.entries(regionTokens())) {
+    if (token) return region;
+  }
+
+  throw new Error('Session token not set for any region');
+}
+
 export default class NsoClient
 {
   constructor(region, nintendoToken) {
@@ -33,7 +41,7 @@ export default class NsoClient
   }
 
   static make(region = null) {
-    region ??= 'US';
+    region ??= getDefaultRegion();
     let tokens = regionTokens();
 
     if (!Object.keys(tokens).includes(region)) {

--- a/app/splatnet/index.mjs
+++ b/app/splatnet/index.mjs
@@ -10,7 +10,12 @@ import SplatNet3Client, { SPLATNET3_WEB_SERVICE_ID } from "./SplatNet3Client.mjs
 export async function warmCaches() {
   console.info('Warming caches...');
 
-  for (let region of Object.keys(regionTokens())) {
+  for (let [region, token] of Object.entries(regionTokens())) {
+    if (!token) {
+      console.warn('Session token not set for region %s', region);
+      continue;
+    }
+
     await warmCache(region);
   }
 }

--- a/docker/nginx/conf.d/default.conf
+++ b/docker/nginx/conf.d/default.conf
@@ -12,4 +12,9 @@ server {
     location ~ /nso/g/(.*) {
         return 302 https://s.nintendo.com/av5ja-lp1/znca/game/4834290508791808?p=/gesotown/$1;
     }
+
+    # Festival redirect
+    location ~ /nso/f/(.*) {
+        return 302 https://s.nintendo.com/av5ja-lp1/znca/game/4834290508791808?p=/fest_record/$1;
+    }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "cron": "^2.1.0",
         "dotenv": "^16.0.2",
         "ecstatic": "^4.1.4",
+        "ical-generator": "^3.6.0",
         "jsonpath": "^1.1.1",
         "lodash": "^4.17.21",
         "mkdirp": "^1.0.4",
@@ -695,9 +696,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
-      "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
+      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
       "dependencies": {
         "bytes": "3.1.2",
         "content-type": "~1.0.4",
@@ -707,7 +708,7 @@
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
-        "qs": "6.10.3",
+        "qs": "6.11.0",
         "raw-body": "2.5.1",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
@@ -948,13 +949,16 @@
       }
     },
     "node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dependencies": {
         "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
+        "strip-ansi": "^6.0.1",
         "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/color-convert": {
@@ -2059,13 +2063,13 @@
       }
     },
     "node_modules/express": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.1.tgz",
-      "integrity": "sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==",
+      "version": "4.18.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
+      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.0",
+        "body-parser": "1.20.1",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
         "cookie": "0.5.0",
@@ -2084,7 +2088,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "0.1.7",
         "proxy-addr": "~2.0.7",
-        "qs": "6.10.3",
+        "qs": "6.11.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "0.18.0",
@@ -2595,6 +2599,57 @@
         "node": ">= 6"
       }
     },
+    "node_modules/ical-generator": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/ical-generator/-/ical-generator-3.6.0.tgz",
+      "integrity": "sha512-QDVRLdiVHNzQYjsi6fSJVVSIUqQcHfgmHr/xBuTE+/YNyO6Duj64TCbtV8Gy/wwWEYhp9dB95hRSNOgtwxtBWg==",
+      "dependencies": {
+        "uuid-random": "^1.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "@touch4it/ical-timezones": ">=1.6.0",
+        "@types/luxon": ">= 1.26.0",
+        "@types/mocha": ">= 8.2.1",
+        "@types/node": ">= 15.0.0",
+        "dayjs": ">= 1.10.0",
+        "luxon": ">= 1.26.0",
+        "moment": ">= 2.29.0",
+        "moment-timezone": ">= 0.5.33",
+        "rrule": ">= 2.6.8"
+      },
+      "peerDependenciesMeta": {
+        "@touch4it/ical-timezones": {
+          "optional": true
+        },
+        "@types/luxon": {
+          "optional": true
+        },
+        "@types/mocha": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "dayjs": {
+          "optional": true
+        },
+        "luxon": {
+          "optional": true
+        },
+        "moment": {
+          "optional": true
+        },
+        "moment-timezone": {
+          "optional": true
+        },
+        "rrule": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -3086,9 +3141,9 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
     "node_modules/nan": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
-      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
       "optional": true
     },
     "node_modules/nanoid": {
@@ -3123,9 +3178,9 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "3.24.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.24.0.tgz",
-      "integrity": "sha512-YPG3Co0luSu6GwOBsmIdGW6Wx0NyNDLg/hriIyDllVsNwnI6UeqaWShxC3lbH4LtEQUgoLP3XR1ndXiDAWvmRw==",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.28.0.tgz",
+      "integrity": "sha512-fRlDb4I0eLcQeUvGq7IY3xHrSb0c9ummdvDSYWfT9+LKP+3jCKw/tKoqaM7r1BAoiAC6GtwyjaGnOz6B3OtF+A==",
       "optional": true,
       "dependencies": {
         "semver": "^7.3.5"
@@ -3752,9 +3807,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
-      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
       "dependencies": {
         "side-channel": "^1.0.4"
       },
@@ -4412,9 +4467,9 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -4551,6 +4606,11 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/uuid-random": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/uuid-random/-/uuid-random-1.3.2.tgz",
+      "integrity": "sha512-UOzej0Le/UgkbWEO8flm+0y+G+ljUon1QWTEZOq1rnMAsxo2+SckbiZdKzAHHlVh6gJqI1TjC/xwgR50MuCrBQ=="
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -4811,17 +4871,17 @@
       }
     },
     "node_modules/yargs": {
-      "version": "17.5.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
-      "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
+      "version": "17.6.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
+      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
       "dependencies": {
-        "cliui": "^7.0.2",
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
         "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^21.0.0"
+        "yargs-parser": "^21.1.1"
       },
       "engines": {
         "node": ">=12"
@@ -5324,9 +5384,9 @@
       }
     },
     "body-parser": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
-      "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
+      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
       "requires": {
         "bytes": "3.1.2",
         "content-type": "~1.0.4",
@@ -5336,7 +5396,7 @@
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
-        "qs": "6.10.3",
+        "qs": "6.11.0",
         "raw-body": "2.5.1",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
@@ -5493,12 +5553,12 @@
       }
     },
     "cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "requires": {
         "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
+        "strip-ansi": "^6.0.1",
         "wrap-ansi": "^7.0.0"
       }
     },
@@ -6200,13 +6260,13 @@
       "optional": true
     },
     "express": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.1.tgz",
-      "integrity": "sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==",
+      "version": "4.18.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
+      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
       "requires": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.0",
+        "body-parser": "1.20.1",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
         "cookie": "0.5.0",
@@ -6225,7 +6285,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "0.1.7",
         "proxy-addr": "~2.0.7",
-        "qs": "6.10.3",
+        "qs": "6.11.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "0.18.0",
@@ -6612,6 +6672,14 @@
         "debug": "4"
       }
     },
+    "ical-generator": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/ical-generator/-/ical-generator-3.6.0.tgz",
+      "integrity": "sha512-QDVRLdiVHNzQYjsi6fSJVVSIUqQcHfgmHr/xBuTE+/YNyO6Duj64TCbtV8Gy/wwWEYhp9dB95hRSNOgtwxtBWg==",
+      "requires": {
+        "uuid-random": "^1.3.2"
+      }
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -6959,9 +7027,9 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
     "nan": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
-      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
       "optional": true
     },
     "nanoid": {
@@ -6987,9 +7055,9 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
     },
     "node-abi": {
-      "version": "3.24.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.24.0.tgz",
-      "integrity": "sha512-YPG3Co0luSu6GwOBsmIdGW6Wx0NyNDLg/hriIyDllVsNwnI6UeqaWShxC3lbH4LtEQUgoLP3XR1ndXiDAWvmRw==",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.28.0.tgz",
+      "integrity": "sha512-fRlDb4I0eLcQeUvGq7IY3xHrSb0c9ummdvDSYWfT9+LKP+3jCKw/tKoqaM7r1BAoiAC6GtwyjaGnOz6B3OtF+A==",
       "optional": true,
       "requires": {
         "semver": "^7.3.5"
@@ -7393,9 +7461,9 @@
       }
     },
     "qs": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
-      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
       "requires": {
         "side-channel": "^1.0.4"
       }
@@ -7841,9 +7909,9 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -7940,6 +8008,11 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+    },
+    "uuid-random": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/uuid-random/-/uuid-random-1.3.2.tgz",
+      "integrity": "sha512-UOzej0Le/UgkbWEO8flm+0y+G+ljUon1QWTEZOq1rnMAsxo2+SckbiZdKzAHHlVh6gJqI1TjC/xwgR50MuCrBQ=="
     },
     "vary": {
       "version": "1.1.2",
@@ -8103,17 +8176,17 @@
       }
     },
     "yargs": {
-      "version": "17.5.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
-      "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
+      "version": "17.6.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
+      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
       "requires": {
-        "cliui": "^7.0.2",
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
         "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^21.0.0"
+        "yargs-parser": "^21.1.1"
       }
     },
     "yargs-parser": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "cron": "^2.1.0",
     "dotenv": "^16.0.2",
     "ecstatic": "^4.1.4",
+    "ical-generator": "^3.6.0",
     "jsonpath": "^1.1.1",
     "lodash": "^4.17.21",
     "mkdirp": "^1.0.4",


### PR DESCRIPTION
This adds generated Splatfest calendars for each region, based on splatoon2.ink's calendars (https://github.com/misenhower/splatoon2.ink/issues/14).

- Each event has a link to SplatNet 3, redirected through https://splatoon3.ink/nso/f/.... I updated the nginx configuration but I don't know if anything else needs to be updated to support this.
- Images for each Splatfest are embedded in the generated calendar. This is done manually after generating the calendar because the library I used only supports adding attachment links. The macOS Calendar app just shows this as an attachment, possibly some calendar apps could show these in the event descriptions but this could be removed to reduce the calendar size.

I also added support for running the data updaters without tokens for all regions to test this. (https://github.com/misenhower/splatoon3.ink/commit/0e4812079f4c1c507cc274fb1f08a9d9f3ae5174)

Example generated calendar: https://gist.github.com/samuelthomas2774/a7fd73ca923ef5c1fb070bdc610bf50e.

<img width="522" alt="Screenshot 2022-11-07 at 09 42 00" src="https://user-images.githubusercontent.com/8474065/200395251-78f6e4db-0cb7-4065-b9b8-7b3f20113679.png">