### PR TITLE
Add Content Wrapper for Splatfest Results

### DIFF
--- a/app/index.mjs
+++ b/app/index.mjs
@@ -4,6 +4,7 @@ import cron from './cron.mjs';
 import { sendStatuses, testStatuses } from './social/index.mjs';
 import { updateAll } from './data/index.mjs';
 import { warmCaches } from "./splatnet/index.mjs";
+import MastodonClient from './social/clients/MastodonClient.mjs';
 
 consoleStamp(console);
 dotenv.config();
@@ -12,6 +13,7 @@ const actions = {
   cron,
   social: sendStatuses,
   socialTest: testStatuses,
+  socialTestMastodon: () => testStatuses([new MastodonClient]),
   splatnet: updateAll,
   warmCaches,
 }

--- a/app/social/Status.mjs
+++ b/app/social/Status.mjs
@@ -1,5 +1,6 @@
 export default class Status
 {
   status = null;
+  contentWrapper = null;
   media = [];
 }

--- a/app/social/clients/MastodonClient.mjs
+++ b/app/social/clients/MastodonClient.mjs
@@ -42,6 +42,8 @@ export default class MastodonClient extends Client
     // Send status
     await masto.statuses.create({
       status: status.status,
+      spoilerText: status.contentWrapper,
+      sensitive: !!status.contentWrapper, // Without the sensitive property the image is still visible
       mediaIds,
     });
   }

--- a/app/social/generators/SplatfestResultsStatus.mjs
+++ b/app/social/generators/SplatfestResultsStatus.mjs
@@ -35,6 +35,16 @@ export default class SplatfestResultsStatus extends StatusGenerator
     return `Splatfest results: Team ${winningTeam.teamName} wins! #splatfest #splatoon3`;
   }
 
+  async _getContentWrapper() {
+    let festival = await this.getFestival();
+
+    if (!festival || !festival.hasResults) {
+      return false;
+    }
+
+    return `${festival.title} Splatfest Results`;
+  }
+
   /** @param {ScreenshotHelper} screenshotHelper */
   async _getMedia(screenshotHelper) {
     let media = new Media;

--- a/app/social/generators/StatusGenerator.mjs
+++ b/app/social/generators/StatusGenerator.mjs
@@ -67,6 +67,7 @@ export default class StatusGenerator
 
     const status = new Status;
     status.status = await this._getStatus();
+    status.contentWrapper = await this._getContentWrapper();
 
     let media = await this.getMedia(screenshotHelper);
     if (media && !Array.isArray(media)) {
@@ -84,6 +85,10 @@ export default class StatusGenerator
   }
 
   async _getStatus () {
+    //
+  }
+
+  async _getContentWrapper() {
     //
   }
 

--- a/app/social/index.mjs
+++ b/app/social/index.mjs
@@ -34,10 +34,10 @@ export function defaultStatusGeneratorManager() {
   );
 }
 
-export function testStatusGeneratorManager() {
+export function testStatusGeneratorManager(additionalClients) {
   return new StatusGeneratorManager(
     defaultStatusGenerators(),
-    [new FileWriter],
+    [new FileWriter, ...additionalClients],
   );
 }
 
@@ -45,6 +45,6 @@ export function sendStatuses() {
   return defaultStatusGeneratorManager().sendStatuses();
 }
 
-export function testStatuses() {
-  return testStatusGeneratorManager().sendStatuses(true);
+export function testStatuses(additionalClients = []) {
+  return testStatusGeneratorManager(additionalClients).sendStatuses(true);
 }

--- a/docker/nginx/conf.d/default.conf
+++ b/docker/nginx/conf.d/default.conf
@@ -8,6 +8,10 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
+    # Docker reverse proxy IP passthrough
+    set_real_ip_from 172.16.0.0/12;
+    real_ip_header X-Real-IP;
+
     # Force browsers to check for updated data
     location /data/ {
         add_header Cache-Control no-cache;

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "cron": "node app/index.mjs cron",
     "social": "node app/index.mjs social",
     "social:test": "node app/index.mjs socialTest",
+    "social:test:mastodon": "node app/index.mjs socialTestMastodon",
     "splatnet": "node app/index.mjs splatnet",
     "warmCaches": "node app/index.mjs warmCaches"
   },


### PR DESCRIPTION
Some people may prefer to learn of the results by watching the in-game news instead of it being spoiled to them. This pull request adds a content wrapper for this to the Splatfest Results status. An example of a status with this is at https://fediverse.catgirlin.space/notice/AR9bBiN12CdkemaZu4

Additionally, this pull request adds the npm script `social:test:mastodon`. I have attempted to implement this in a clean way, with the `testStatuses` function taking an array of clients to use in addition to the `FileWriter` client. 