### PR TITLE
Add Tricolour Battle result

### DIFF
--- a/src/components/SplatfestResultsBox.vue
+++ b/src/components/SplatfestResultsBox.vue
@@ -58,7 +58,7 @@ function results(ratioKey, topKey) {
 }
 
 const resultRows = computed(() => {
-  return [
+  const rows = [
     {
       title: 'Conch Shells',
       results: results('horagaiRatio', 'isHoragaiRatioTop'),
@@ -76,6 +76,15 @@ const resultRows = computed(() => {
       results: results('challengeContributionRatio', 'isChallengeContributionRatioTop'),
     },
   ];
+
+  if (props.festival.teams.find(t => t.result.tricolorContributionRatio !== null)) {
+    rows.push({
+      title: 'Tricolor Battle',
+      results: results('tricolorContributionRatio', 'isTricolorContributionRatioTop'),
+    });
+  }
+
+  return rows;
 });
 
 const winner = computed(() => props.festival.teams.find(t => t.result.isWinner));


### PR DESCRIPTION
This pull request adds the Tricolour Battle row to the Splatfest results box/screenshot:

Appearance in SplatNet 3:

<img width="374" alt="Screenshot 2022-12-31 at 07 39 43" src="https://user-images.githubusercontent.com/8474065/210131395-d4b8eca1-24a8-4d21-a7ff-84ca932ebe68.png">

Screenshot:

![splatfestResults](https://user-images.githubusercontent.com/8474065/210131552-b400a936-4e9a-403b-89f5-da87cbaf46be.png)