### PR TITLE
Fetch all Splatfest ranking holders

### DIFF
--- a/app/data/updaters/FestivalRankingUpdater.mjs
+++ b/app/data/updaters/FestivalRankingUpdater.mjs
@@ -2,6 +2,14 @@ import fs from 'fs/promises';
 import prefixedConsole from "../../common/prefixedConsole.mjs";
 import DataUpdater from "./DataUpdater.mjs";
 
+function getFestId(id) {
+  return Buffer.from(id, 'base64').toString().match(/^Fest-[A-Z]+:(.+)$/)?.[1] ?? id;
+}
+
+function getFestTeamId(id) {
+  return Buffer.from(id, 'base64').toString().match(/^FestTeam-[A-Z]+:((.+):(.+))$/)?.[1] ?? id;
+}
+
 export default class FestivalRankingUpdater extends DataUpdater
 {
   name = 'FestivalRankingUpdater';
@@ -25,7 +33,7 @@ export default class FestivalRankingUpdater extends DataUpdater
   ];
 
   get console() {
-    this._console ??= prefixedConsole('Updater', this.region, this.name, this.festID);
+    this._console ??= prefixedConsole('Updater', this.region, this.name, getFestId(this.festID));
 
     return this._console;
   }
@@ -50,7 +58,30 @@ export default class FestivalRankingUpdater extends DataUpdater
     return false;
   }
 
-  getData(locale) {
-    return this.splatnet(locale).getFestRankingData(this.festID);
+  async getData(locale) {
+    const data = await this.splatnet(locale).getFestRankingData(this.festID);
+
+    for (const team of data.data.fest.teams) {
+      let pageInfo = team.result?.rankingHolders.pageInfo;
+
+      while (pageInfo.hasNextPage) {
+        this.console.log('Fetching next page for team %s (%s), cursor %s',
+          getFestTeamId(team.id), team.teamName, pageInfo.endCursor);
+
+        const page = await this.splatnet(locale).getFestRankingPage(team.id, pageInfo.endCursor);
+
+        team.result.rankingHolders = {
+          edges: [
+            ...team.result.rankingHolders.edges,
+            ...page.data.node.result.rankingHolders.edges,
+          ],
+          pageInfo: page.data.node.result.rankingHolders.pageInfo,
+        };
+
+        pageInfo = page.data.node.result.rankingHolders.pageInfo;
+      }
+    }
+
+    return data;
   }
 }

--- a/app/data/updaters/FestivalRankingUpdater.mjs
+++ b/app/data/updaters/FestivalRankingUpdater.mjs
@@ -20,7 +20,7 @@ export default class FestivalRankingUpdater extends DataUpdater
 
     this.festID = festID;
     this.endTime = endTime;
-    this.filename += `.${region}.${festID}`;
+    this.filename += `.${region}.${getFestId(festID)}`;
   }
 
   imagePaths = [

--- a/app/data/updaters/FestivalUpdater.mjs
+++ b/app/data/updaters/FestivalUpdater.mjs
@@ -40,8 +40,10 @@ export default class FestivalUpdater extends DataUpdater
 
       Object.assign(node, detailResult.data.fest);
 
-      let rankingUpdater = new FestivalRankingUpdater(this.region, node.id, node.endTime);
-      await rankingUpdater.updateIfNeeded();
+      if (node.teams.find(t => t.result)) {
+        let rankingUpdater = new FestivalRankingUpdater(this.region, node.id, node.endTime);
+        await rankingUpdater.updateIfNeeded();
+      }
     }
 
     return result;

--- a/app/splatnet/SplatNet3Client.mjs
+++ b/app/splatnet/SplatNet3Client.mjs
@@ -140,6 +140,10 @@ export default class SplatNet3Client
     return this.getGraphQLPersistedQuery(1, '4869de13d0d209032b203608cb598aef', { festId });
   }
 
+  getFestRankingPage(teamId, cursor) {
+    return this.getGraphQLPersistedQuery(1, 'be2eb9e9b8dd680519eb59cc46c1a32b', { cursor, first: 25, id: teamId });
+  }
+
   getCurrentFestData() {
     return this.getGraphQLPersistedQuery(1, 'c0429fd738d829445e994d3370999764');
   }


### PR DESCRIPTION
Since SplatNet 3 2.0.0-8a061f6c the Splatfest Top 100 rankings are paginated and only the first 25 ranking holders for each team are included in the result (https://github.com/samuelthomas2774/nxapi/discussions/11#discussioncomment-4267973). This pull request fetches all additional pages for each team and merges them into a single file. I also changed the filename to use the decoded fest ID instead of the global ID and added a check to skip downloading rankings for active/future Splatfests.