### PR TITLE
Fix margin between each splatfest team icon

### DIFF
--- a/src/components/SplatfestResultsBox.vue
+++ b/src/components/SplatfestResultsBox.vue
@@ -7,9 +7,9 @@
 
       <div class="mx-2 px-1 bg-zinc-700 bg-opacity-50 backdrop-blur-sm rounded-lg">
         <div class="flex justify-center py-2">
-          <div class="w-36 sm:mx-2"></div>
+          <div class="w-36 -mx-1"></div>
           <template v-for="team in festival.teams" :key="team.id">
-            <div class="w-16 sm:w-20 mx-2 flex justify-center py-1 rounded" :style="`background-color: ${toRgba(team.color)};`">
+            <div class="w-20 mx-2 flex justify-center py-1 rounded" :style="`background-color: ${toRgba(team.color)};`">
               <img :src="team.image.url" class="w-6 h-6" />
             </div>
           </template>


### PR DESCRIPTION
This pull request fixes the margin between each splatfest team icon.

Before:
![grafik](https://user-images.githubusercontent.com/66379522/219093120-019a2927-a8ab-44d9-bdd4-dbe98c8e748f.png)

After:
![grafik](https://user-images.githubusercontent.com/66379522/219093194-04255729-75b1-45c4-b8c0-9b657671c2e1.png)
