### PR TITLE
Only added a few untranslated keys

### DIFF
--- a/src/assets/i18n/de-DE.json
+++ b/src/assets/i18n/de-DE.json
@@ -38,7 +38,8 @@
     "title": "Salmon Run",
     "weapons": "Verfügbare Waffen",
     "bigrun": "Big Run",
-    "eggstrawork": "Team-Wettkampf"
+    "eggstrawork": "Team-Wettkampf",
+    "opens": "Schicht öffnet"
   },
   "festival": {
     "title": "Splatfeste",
@@ -90,5 +91,8 @@
     "term": "Diese Website steht in keiner Verbindung zu Nintendo. Alle Produktnamen, Logos und Marken sind Eigentum der jeweiligen Inhaber.",
     "about": "Über",
     "data": "Daten"
+  },
+  "social": {
+    "description": "Bleib auf dem Laufenden über die neuesten Nachrichten und Updates von Splatoon3.ink auf den sozialen Medien! In der Liste unten findest du deine Lieblingsplattform."
   }
 }

--- a/src/assets/i18n/en-GB.json
+++ b/src/assets/i18n/en-GB.json
@@ -37,7 +37,8 @@
     "title": "Salmon Run",
     "weapons": "Supplied Weapons",
     "bigrun": "Big Run",
-    "eggstrawork": "Eggstra Work"
+    "eggstrawork": "Eggstra Work",
+    "opens": "Shift opens"
   },
   "festival": {
     "title": "Splatfests",
@@ -66,5 +67,8 @@
     "sale": "Gear on Sale Now",
     "dailydrop": "The Daily Drop",
     "order": "Order"
+  },
+  "social": {
+    "description": "Stay up to date with the latest news and updates from Splatoon3.ink on social media! Check the list below to find your favorite platform."
   }
 }

--- a/src/assets/i18n/en-US.json
+++ b/src/assets/i18n/en-US.json
@@ -38,7 +38,8 @@
     "title": "Salmon Run",
     "weapons": "Supplied Weapons",
     "bigrun": "Big Run",
-    "eggstrawork": "Eggstra Work"
+    "eggstrawork": "Eggstra Work",
+    "opens": "Shift opens"
   },
   "festival": {
     "title": "Splatfests",
@@ -91,5 +92,8 @@
     "about": "About",
     "socials": "Social Media",
     "data": "Data"
+  },
+  "social": {
+    "description": "Stay up to date with the latest news and updates from Splatoon3.ink on social media! Check the list below to find your favorite platform."
   }
 }

--- a/src/components/gear/RegularGear.vue
+++ b/src/components/gear/RegularGear.vue
@@ -14,13 +14,8 @@
 
     <div class="pb-24 lg:pb-36">
       <div class="text-center py-4">
-        <SquidTape
-          class="font-splatoon1 text-2xl text-black rounded-sm -rotate-2 z-10"
-          bg="bg-splatoon-orange"
-          squid-bg="bg-black"
-          border="border border-black"
-          squid-size="15px"
-        >
+        <SquidTape class="font-splatoon1 text-2xl text-black rounded-sm -rotate-2 z-10" bg="bg-splatoon-orange"
+          squid-bg="bg-black" border="border border-black" squid-size="15px">
           <div class="px-1">
             {{ $t("gear.sale") }}
           </div>
@@ -46,7 +41,7 @@
       <template v-else>
         <div class="h-24 flex items-center justify-center">
           <div class="font-splatoon2 text-black">
-            Check back soon!
+            {{ $t('times.checkback') }}
           </div>
         </div>
       </template>

--- a/src/components/salmonrun/ExpandedSalmonRunRow.vue
+++ b/src/components/salmonrun/ExpandedSalmonRunRow.vue
@@ -13,7 +13,7 @@
         <KingSalmonid v-if="!eggstra" :schedule="schedule" class="inline-block -mb-1 mr-2 drop-shadow-ruleIcon" />
 
         <div v-if="time.isUpcoming(schedule.startTime)" class="inline-block">
-          Shift opens
+          {{ $t('salmonrun.opens') }}
           {{ $t('time.in', { time: formatDurationHoursFromNow(schedule.startTime, true) }) }}
         </div>
         <div v-else class="inline-block">
@@ -21,10 +21,8 @@
         </div>
       </div>
 
-      <div
-        v-if="schedule.isBigRun"
-        class="bg-zinc-800 bg-opacity-80 text-sm text-white rounded-lg px-2 border-2 border-splatoon-bigRun"
-      >
+      <div v-if="schedule.isBigRun"
+        class="bg-zinc-800 bg-opacity-80 text-sm text-white rounded-lg px-2 border-2 border-splatoon-bigRun">
         <img src="@/assets/img/modes/coop.bigrun.svg" :title="$t('salmonrun.bigrun')" class="w-4 inline-block" />
         {{ $t('salmonrun.bigrun') }}
       </div>
@@ -45,10 +43,7 @@
         </div>
 
         <div class="bg-zinc-900 bg-opacity-30 rounded-full backdrop-blur-sm px-2">
-          <SalmonRunWeapons
-            :weapons="schedule.settings.weapons"
-            weapon-class="w-10 sm:w-14"
-          />
+          <SalmonRunWeapons :weapons="schedule.settings.weapons" weapon-class="w-10 sm:w-14" />
         </div>
       </div>
     </div>

--- a/src/views/SocialsView.vue
+++ b/src/views/SocialsView.vue
@@ -15,8 +15,7 @@
                   </h1>
 
                   <div>
-                    Stay up to date with the latest news and updates from Splatoon3.ink on social media!
-                    Check the list below to find your favorite platform.
+                    {{ $t('social.description') }}
                   </div>
 
                   <div>
@@ -37,9 +36,11 @@
             </ProductContainer>
 
             <img class="absolute hidden sm:block -top-6 right-36 w-32 -rotate-3" src="@/assets/img/tape/tape-2.png" />
-            <img class="absolute hidden sm:block top-20 -left-16 w-20 rotate-3" src="@/assets/img/stickers/sticker-2-red.png" />
+            <img class="absolute hidden sm:block top-20 -left-16 w-20 rotate-3"
+              src="@/assets/img/stickers/sticker-2-red.png" />
             <img class="absolute -bottom-4 -right-12 w-32 -rotate-6" src="@/assets/img/stickers/sticker-1.png" />
-            <img class="absolute hidden sm:block -bottom-4 left-40 w-60 rotate-3" src="@/assets/img/stickers/sticker-8.png" />
+            <img class="absolute hidden sm:block -bottom-4 left-40 w-60 rotate-3"
+              src="@/assets/img/stickers/sticker-8.png" />
           </div>
         </div>
       </div>


### PR DESCRIPTION
I happened to notice that "Check back soon!", "Shift opens" and the text in the social view were not translated. 

"Check back soon!" was hard coded but should not normally appear.
And on the Social View page, the "Splatoon 3 Schedules" button, the NavBar and the footer are already translated anyway, so I did that as well
