### PR TITLE
Fix tricolor on frontend and social media posts

### DIFF
--- a/app/social/generators/SchedulesStatus.mjs
+++ b/app/social/generators/SchedulesStatus.mjs
@@ -45,8 +45,12 @@ export default class SchedulesStatus extends StatusGenerator
         `– Pro: ${festProStages[0].name} and ${festProStages[1].name}`,
       ];
 
-      if(stages.tricolor?.isTricolorActive) {
+      if(stages.tricolor?.isTricolorActive && stages.tricolor.tricolorStage) {
         lines.push(`– Tricolor: ${stages.tricolor.tricolorStage.name}`);
+      }
+
+      if(stages.tricolor?.isTricolorActive && stages.tricolor.tricolorStages) {
+        lines.push(`– Tricolor: ${stages.tricolor.tricolorStages[0].name}`);
       }
       return lines.join('\n');
 

--- a/src/components/TricolorBox.vue
+++ b/src/components/TricolorBox.vue
@@ -34,7 +34,7 @@
           </div>
         </div>
 
-        <div class="flex space-x-1">
+        <div class="flex space-x-1" v-if="tricolor?.tricolorStage">
           <div class="flex-1 relative">
             <StageImage
               img-class="rounded-xl"
@@ -42,6 +42,16 @@
             />
           </div>
         </div>
+
+        <div class="flex space-x-1" v-if="tricolor?.tricolorStages">
+          <div class="flex-1 relative">
+            <StageImage
+              img-class="rounded-xl"
+              :stage="tricolor?.tricolorStages?.[0]"
+            />
+          </div>
+        </div>
+        
       </div>
     </div>
   </ProductContainer>

--- a/src/components/TricolorBox.vue
+++ b/src/components/TricolorBox.vue
@@ -34,7 +34,7 @@
           </div>
         </div>
 
-        <div class="flex space-x-1" v-if="tricolor?.tricolorStage">
+        <div v-if="tricolor?.tricolorStage" class="flex space-x-1">
           <div class="flex-1 relative">
             <StageImage
               img-class="rounded-xl"
@@ -43,7 +43,7 @@
           </div>
         </div>
 
-        <div class="flex space-x-1" v-if="tricolor?.tricolorStages">
+        <div v-if="tricolor?.tricolorStages" class="flex space-x-1">
           <div class="flex-1 relative">
             <StageImage
               img-class="rounded-xl"
@@ -51,7 +51,6 @@
             />
           </div>
         </div>
-        
       </div>
     </div>
   </ProductContainer>

--- a/src/components/screenshots/ScreenshotTricolorBox.vue
+++ b/src/components/screenshots/ScreenshotTricolorBox.vue
@@ -33,7 +33,7 @@
           </div>
         </div>
 
-        <div class="space-y-8" v-if="tricolor?.tricolorStage">
+        <div v-if="tricolor?.tricolorStage" class="space-y-8">
           <StageImage
             img-class="rounded-2xl"
             :stage="tricolor?.tricolorStage"
@@ -41,7 +41,7 @@
           />
         </div>
 
-        <div class="space-y-8" v-if="tricolor?.tricolorStages">
+        <div v-if="tricolor?.tricolorStages" class="space-y-8">
           <StageImage
             img-class="rounded-2xl"
             :stage="tricolor?.tricolorStages[0]"

--- a/src/components/screenshots/ScreenshotTricolorBox.vue
+++ b/src/components/screenshots/ScreenshotTricolorBox.vue
@@ -33,10 +33,18 @@
           </div>
         </div>
 
-        <div class="space-y-8">
+        <div class="space-y-8" v-if="tricolor?.tricolorStage">
           <StageImage
             img-class="rounded-2xl"
             :stage="tricolor?.tricolorStage"
+            text-size="text-xl"
+          />
+        </div>
+
+        <div class="space-y-8" v-if="tricolor?.tricolorStages">
+          <StageImage
+            img-class="rounded-2xl"
+            :stage="tricolor?.tricolorStages[0]"
             text-size="text-xl"
           />
         </div>

--- a/src/stores/splatfests.mjs
+++ b/src/stores/splatfests.mjs
@@ -65,16 +65,20 @@ function defineSplatfestRegionStore(region) {
 
       // Move the thumbnail image to "thumbnailImage" and pull in the high-res image for the stage
       if (fest.tricolorStage && !fest.tricolorStage.thumbnailImage) {
-        fest.tricolorStage.thumbnailImage = fest.tricolorStage.image;
+        fest.tricolorStage.thumbnailImage = fest.tricolorStage.image.url;
         fest.tricolorStage.image =
           vsStages.nodes.find(s => s.id === fest.tricolorStage.id)?.originalImage ||
           fest.tricolorStage.image;
       }
 
+      if (fest.tricolorStages) {
+        fest.tricolorStages.forEach(stage => { if (!stage.thumbnailImage) stage.thumbnailImage = stage.image }); 
+      }
+
       return {
         ...fest,
-        isTricolorActive: time.isActive(fest.midtermTime, fest.endTime),
-        startTime: fest.midtermTime,
+        isTricolorActive: time.startTime == time.midtermTime ? time.isActive(fest.startTime, fest.endTime) : time.isActive(time.midtermTime),
+        startTime: time.startTime == time.midtermTime ? fest.startTime : fest.midtermTime,
         endTime: fest.endTime,
       };
     });

--- a/src/stores/splatfests.mjs
+++ b/src/stores/splatfests.mjs
@@ -72,13 +72,13 @@ function defineSplatfestRegionStore(region) {
       }
 
       if (fest.tricolorStages) {
-        fest.tricolorStages.forEach(stage => { if (!stage.thumbnailImage) stage.thumbnailImage = stage.image }); 
+        fest.tricolorStages.forEach(stage => stage.thumbnailImage = stage.image); 
       }
 
       return {
         ...fest,
-        isTricolorActive: time.startTime == time.midtermTime ? time.isActive(fest.startTime, fest.endTime) : time.isActive(time.midtermTime),
-        startTime: time.startTime == time.midtermTime ? fest.startTime : fest.midtermTime,
+        isTricolorActive: fest.tricolorStages ? time.isActive(fest.startTime, fest.endTime) : time.isActive(time.midtermTime, time.endTime),
+        startTime: fest.tricolorStages ? fest.startTime : fest.midtermTime,
         endTime: fest.endTime,
       };
     });

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -15,10 +15,10 @@
           </template>
           <template v-else>
             <div class="flex flex-wrap justify-center items-center gap-6">
-              <SplatfestBox :festival="activeFestivals[0]" class="md:max-w-md 2xl:max-w-lg md:-rotate-1" />
+              <SplatfestBox :festival="activeFestivals[0]" class="md:max-w-md 2xl:max-w-lg md:rotate-1" />
               <ScheduleBox type="splatfestOpen" class="md:max-w-md 2xl:max-w-lg md:-rotate-1" />
-              <ScheduleBox type="splatfestPro" class="md:max-w-md 2xl:max-w-lg md:-rotate-1" />
-              <TricolorBox v-if="isTricolorActive" class="md:max-w-md 2xl:max-w-lg md:rotate-1" />
+              <ScheduleBox type="splatfestPro" class="md:max-w-md 2xl:max-w-lg md:rotate-1" />
+              <TricolorBox v-if="isTricolorActive" class="md:max-w-md 2xl:max-w-lg md:-rotate-1" />
             </div>
           </template>
         </template>


### PR DESCRIPTION
This PR fixes tricolor not being displayed on the page and also not being included in social media posts for the grand festival.

I added a check to isTricolorActive whether or not we got a `currentfest.tricolorStages` object to set the start time to the currentfest's starttime, additional checks for TricolorBox and ScreenshotTricolorBox to include the `tricolorStages` image and for the social media posts, to display the current tricolor stage name.

Let's just hope I didn't break anything. 🙏