### PR TITLE
Display missing `tricolorStages` in TricolorBoxes

### DIFF
--- a/app/social/generators/SchedulesStatus.mjs
+++ b/app/social/generators/SchedulesStatus.mjs
@@ -50,7 +50,11 @@ export default class SchedulesStatus extends StatusGenerator
       }
 
       if(stages.tricolor?.isTricolorActive && stages.tricolor.tricolorStages) {
-        lines.push(`– Tricolor: ${stages.tricolor.tricolorStages[0].name}`);
+        if(stages.tricolor.tricolorStages.length == 1) {
+          lines.push(`– Tricolor: ${stages.tricolor.tricolorStages[0].name}`);
+        } else {
+          lines.push(`– Tricolor: ${stages.tricolor.tricolorStages[0].name} and ${stages.tricolor.tricolorStages[1].name}`);
+        }
       }
       return lines.join('\n');
 

--- a/src/components/TricolorBox.vue
+++ b/src/components/TricolorBox.vue
@@ -43,14 +43,26 @@
           </div>
         </div>
 
-        <div v-if="tricolor?.tricolorStages" class="flex space-x-1">
-          <div class="flex-1 relative">
+        <div v-if="tricolor?.tricolorStages">
+          <div v-if="tricolor?.tricolorStages.length == 1" class="flex space-x-1">
             <StageImage
               img-class="rounded-xl"
               :stage="tricolor?.tricolorStages?.[0]"
             />
           </div>
+          
+          <div v-else class="flex space-x-1">
+            <StageImage
+              img-class="rounded-l-xl"
+              :stage="tricolor?.tricolorStages?.[0]"
+            />
+            <StageImage
+              img-class="rounded-r-xl"
+              :stage="tricolor?.tricolorStages?.[1]"
+            />
+          </div>
         </div>
+
       </div>
     </div>
   </ProductContainer>

--- a/src/components/screenshots/ScreenshotTricolorBox.vue
+++ b/src/components/screenshots/ScreenshotTricolorBox.vue
@@ -43,8 +43,11 @@
 
         <div v-if="tricolor?.tricolorStages" class="space-y-8">
           <StageImage
+            v-for="tricolorStage in tricolor.tricolorStages"
+            :key="tricolorStage.id"
+            class="flex-1"
             img-class="rounded-2xl"
-            :stage="tricolor?.tricolorStages[0]"
+            :stage="tricolorStage"
             text-size="text-xl"
           />
         </div>

--- a/src/stores/splatfests.mjs
+++ b/src/stores/splatfests.mjs
@@ -77,8 +77,8 @@ function defineSplatfestRegionStore(region) {
 
       return {
         ...fest,
-        isTricolorActive: fest.tricolorStages ? time.isActive(fest.startTime, fest.endTime) : time.isActive(time.midtermTime, time.endTime),
-        startTime: fest.tricolorStages ? fest.startTime : fest.midtermTime,
+        isTricolorActive: time.isActive(fest.midtermTime, fest.endTime),
+        startTime: fest.midtermTime,
         endTime: fest.endTime,
       };
     });


### PR DESCRIPTION
This PR changes both TricolorBoxes to display the second Tricolor stage. ~~That's it.~~

Edit: I missed social media posts and somewhat reverted 149f767 to display tricolor start & end times properly again.