### PR TITLE
Remove obsolete frontend deployment job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,40 +7,6 @@ on:
       - develop
 
 jobs:
-  deploy-frontend:
-    runs-on: ubuntu-latest
-
-    environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '22'
-
-    - name: Install dependencies
-      run: npm ci
-
-    - name: Build
-      run: npm run build
-      env:
-        VITE_DATA_FROM: ${{ vars.VITE_DATA_FROM }}
-
-    - name: Deploy
-      uses: jakejarvis/s3-sync-action@master
-      with:
-        args: --acl public-read
-      env:
-        AWS_S3_ENDPOINT: ${{ secrets.AWS_S3_ENDPOINT }}
-        AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        AWS_REGION: ${{ secrets.AWS_REGION }}
-        SOURCE_DIR: 'dist'
-
   deploy-backend:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Summary

- remove the obsolete S3 frontend build and deployment job after the Cloudflare Pages cutover
- retain the backend container build, registry push, and provenance attestation

## Validation

- workflow YAML parses successfully
- git diff --check passes